### PR TITLE
Fix typo

### DIFF
--- a/salt/qubes-builder/create.sls
+++ b/salt/qubes-builder/create.sls
@@ -113,7 +113,7 @@ features:
 "{{ slsdotpath }}-shutdown-template":
   qvm.shutdown:
     - require:
-      - qvm: "{{ slsdotpath }}-set-management_dispvm-to-default"
+      - qvm: "{{ slsdotpath }}-set-management_dispvm-to-dvm-fedora"
     - name: tpl-{{ slsdotpath }}
     - flags:
       - force


### PR DESCRIPTION
-set-management_dispvm-to-dvm-fedora was incorrectly replaced with -set-management_dispvm-to-default