### PR TITLE
fix: remove typo in mullvad-browser install command

### DIFF
--- a/salt/browser/README.md
+++ b/salt/browser/README.md
@@ -66,7 +66,7 @@ sudo qubesctl --skip-dom0 --targets=tpl-browser state.apply browser.install-fire
 
 - Mullvad-Browser:
 ```sh
-sudo qubesctl --skip-dom0 --targets=tpl-browser state.apply browser.install-mullvad-browser
+sudo qubesctl --skip-dom0 --targets=tpl-browser state.apply browser.install-mullvad
 ```
 
 


### PR DESCRIPTION
The mullvad-browser install command had an extraneous '-browser' suffix that was causing the command to fail. This commit removes the unnecessary suffix, correcting the install command so that it can execute properly.