### PR TITLE
fix: Invalid volume size for sys-bitcoin

### DIFF
--- a/salt/sys-bitcoin/create.sls
+++ b/salt/sys-bitcoin/create.sls
@@ -270,7 +270,7 @@ tags:
   cmd.run:
     - require:
       - qvm: {{ slsdotpath }}
-    - name: qvm-volume extend {{ slsdotpath }}:private 1Ti
+    - name: qvm-volume extend {{ slsdotpath }}:private 1024Gi
 
 "{{ slsdotpath }}-extend-builder-private-volume":
   cmd.run:


### PR DESCRIPTION
## Contribution checklist

Before contributing, I, the opener of this request:

-   [x] Agree to use the same license of each modified file;
-   [x] Have followed the [contribution guidelines](docs/CONTRIBUTE.md);
-   [x] Have tested it locally;
-   [x] Have committed locally and not through a git hosting service such as
    GitHub Web; and
-   [x] Have reviewed and updated any documentation if relevant.

Lacking to check any of the above can result in the rejection of the
contribution without no further comment.

## What does this PR aims to accomplish

Simple fix over a `Invalid size: 1TI` while performing `sudo qubectl state.apply sys-bitcoin.create`

## What does this PR change

Change the unit measure from Ti to Gi.
