### PR TITLE
fix: reference local sls included by slsdotpath

### DIFF
--- a/salt/ansible/create.sls
+++ b/salt/ansible/create.sls
@@ -7,7 +7,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 {%- from "qvm/template.jinja" import load -%}
 
 include:
-  - .clone
+  - {{ slsdotpath }}.clone
 
 {% load_yaml as defaults -%}
 name: tpl-{{ slsdotpath }}

--- a/salt/ansible/install.sls
+++ b/salt/ansible/install.sls
@@ -7,7 +7,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 {% if grains['nodename'] != 'dom0' -%}
 
 include:
-  - .install-repo
+  - {{ slsdotpath }}.install-repo
   - utils.tools.common.update
   - dotfiles.copy-sh
   - dotfiles.copy-x11

--- a/salt/browser/create.sls
+++ b/salt/browser/create.sls
@@ -7,7 +7,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 {%- from "qvm/template.jinja" import load -%}
 
 include:
-  - .clone
+  - {{ slsdotpath }}.clone
 
 {% load_yaml as defaults -%}
 name: tpl-{{ slsdotpath }}

--- a/salt/browser/install-chrome.sls
+++ b/salt/browser/install-chrome.sls
@@ -7,8 +7,8 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 {% if grains['nodename'] != 'dom0' -%}
 
 include:
-  - .install-chrome-repo
-  - .install-common
+  - {{ slsdotpath }}.install-chrome-repo
+  - {{ slsdotpath }}.install-common
 
 "{{ slsdotpath }}-avoid-chrome-installing-own-repo":
   file.touch:

--- a/salt/browser/install-chromium.sls
+++ b/salt/browser/install-chromium.sls
@@ -7,7 +7,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 {% if grains['nodename'] != 'dom0' -%}
 
 include:
-  - .install-common
+  - {{ slsdotpath }}.install-common
 
 "{{ slsdotpath }}-installed-chromium":
   pkg.installed:

--- a/salt/browser/install-firefox-esr.sls
+++ b/salt/browser/install-firefox-esr.sls
@@ -7,7 +7,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 {% if grains['nodename'] != 'dom0' -%}
 
 include:
-  - .install-common
+  - {{ slsdotpath }}.install-common
 
 "{{ slsdotpath }}-installed-firefox-esr":
   pkg.installed:

--- a/salt/browser/install-firefox.sls
+++ b/salt/browser/install-firefox.sls
@@ -7,8 +7,8 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 {% if grains['nodename'] != 'dom0' -%}
 
 include:
-  - .install-firefox-repo
-  - .install-common
+  - {{ slsdotpath }}.install-firefox-repo
+  - {{ slsdotpath }}.install-common
 
 "{{ slsdotpath }}-installed-firefox":
   pkg.installed:

--- a/salt/browser/install-lynx.sls
+++ b/salt/browser/install-lynx.sls
@@ -7,7 +7,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 {% if grains['nodename'] != 'dom0' -%}
 
 include:
-  - .install-common
+  - {{ slsdotpath }}.install-common
 
 "{{ slsdotpath }}-installed-lynx":
   pkg.installed:

--- a/salt/browser/install-mullvad.sls
+++ b/salt/browser/install-mullvad.sls
@@ -7,8 +7,8 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 {% if grains['nodename'] != 'dom0' -%}
 
 include:
-  - .install-mullvad-repo
-  - .install-common
+  - {{ slsdotpath }}.install-mullvad-repo
+  - {{ slsdotpath }}.install-common
 
 "{{ slsdotpath }}-installed-mullvad":
   pkg.installed:

--- a/salt/browser/install-w3m.sls
+++ b/salt/browser/install-w3m.sls
@@ -7,7 +7,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 {% if grains['nodename'] != 'dom0' -%}
 
 include:
-  - .install-common
+  - {{ slsdotpath }}.install-common
   - dotfiles.copy-net
 
 "{{ slsdotpath }}-installed-w3m":

--- a/salt/browser/install.sls
+++ b/salt/browser/install.sls
@@ -7,6 +7,6 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 {% if grains['nodename'] != 'dom0' -%}
 
 include:
-  - .install-chromium
+  - {{ slsdotpath }}.install-chromium
 
 {% endif -%}

--- a/salt/debian-minimal/create.sls
+++ b/salt/debian-minimal/create.sls
@@ -9,7 +9,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 {%- import slsdotpath ~ "/template.jinja" as template -%}
 
 include:
-  - .clone
+  - {{ slsdotpath }}.clone
 
 "dvm-{{ template.template }}-absent":
   qvm.absent:

--- a/salt/debian-xfce/create.sls
+++ b/salt/debian-xfce/create.sls
@@ -9,7 +9,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 {%- import slsdotpath ~ "/template.jinja" as template -%}
 
 include:
-  - .clone
+  - {{ slsdotpath }}.clone
 
 "dvm-{{ template.template }}-absent":
   qvm.absent:

--- a/salt/debian/create.sls
+++ b/salt/debian/create.sls
@@ -9,7 +9,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 {%- import slsdotpath ~ "/template.jinja" as template -%}
 
 include:
-  - .clone
+  - {{ slsdotpath }}.clone
 
 "dvm-{{ template.template }}-absent":
   qvm.absent:

--- a/salt/dev/configure.sls
+++ b/salt/dev/configure.sls
@@ -7,7 +7,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 {% if grains['nodename'] != 'dom0' -%}
 
 include:
-  - .home-cleanup
+  - {{ slsdotpath }}.home-cleanup
   - dotfiles.copy-all
 
 {% endif -%}

--- a/salt/dev/create.sls
+++ b/salt/dev/create.sls
@@ -7,7 +7,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 {%- from "qvm/template.jinja" import load -%}
 
 include:
-  - .clone
+  - {{ slsdotpath }}.clone
   - sys-net.show-updatevm-origin
 
 {% load_yaml as defaults -%}

--- a/salt/dev/init.sls
+++ b/salt/dev/init.sls
@@ -11,12 +11,12 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 {#
 include:
 {% if grains['id'] == 'dom0' -%}
-  - .create
+  - {{ slsdotpath }}.create
 {% elif grains['id'] == 'tpl-' ~ slsdotpath -%}
-  - .install
+  - {{ slsdotpath }}.install
 {% elif grains['id'] == 'disp-' ~ slsdotpath -%}
   - utils.tools.zsh.touch-zshrc
 {% elif grains['id'] == slsdotpath -%}
-  - .configure
+  - {{ slsdotpath }}.configure
 {% endif -%}
 #}

--- a/salt/dev/install.sls
+++ b/salt/dev/install.sls
@@ -8,7 +8,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
 include:
   - utils.tools.common.update
-  - .home-cleanup
+  - {{ slsdotpath }}.home-cleanup
   - dotfiles.copy-all
   - utils.tools.zsh
   - sys-pgp.install-client

--- a/salt/dom0/init.sls
+++ b/salt/dom0/init.sls
@@ -7,13 +7,13 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 {% if grains['nodename'] == 'dom0' -%}
 
 include:
-  - .backup
-  - .dotfiles
-  - .helpers
-  - .install
-  - .desktop-kde
-  - .update-settings
-  - .xorg
-  - .screenshot
+  - {{ slsdotpath }}.backup
+  - {{ slsdotpath }}.dotfiles
+  - {{ slsdotpath }}.helpers
+  - {{ slsdotpath }}.install
+  - {{ slsdotpath }}.desktop-kde
+  - {{ slsdotpath }}.update-settings
+  - {{ slsdotpath }}.xorg
+  - {{ slsdotpath }}.screenshot
 
 {% endif -%}

--- a/salt/electrum/configure-hot.sls
+++ b/salt/electrum/configure-hot.sls
@@ -7,6 +7,6 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 {% if grains['nodename'] != 'dom0' -%}
 
 include:
-  - .configure-common
+  - {{ slsdotpath }}.configure-common
 
 {% endif -%}

--- a/salt/electrum/configure.sls
+++ b/salt/electrum/configure.sls
@@ -7,7 +7,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 {% if grains['nodename'] != 'dom0' -%}
 
 include:
-  - .configure-common
+  - {{ slsdotpath }}.configure-common
   - whonix-workstation.configure-offline
 
 {% endif -%}

--- a/salt/electrum/create.sls
+++ b/salt/electrum/create.sls
@@ -9,7 +9,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 {%- import "whonix-workstation/template.jinja" as whonix_workstation -%}
 
 include:
-  - .clone
+  - {{ slsdotpath }}.clone
   - sys-bitcoin.create
 
 {% load_yaml as defaults -%}

--- a/salt/element/create.sls
+++ b/salt/element/create.sls
@@ -7,7 +7,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 {%- from "qvm/template.jinja" import load -%}
 
 include:
-  - .clone
+  - {{ slsdotpath }}.clone
 
 {% load_yaml as defaults -%}
 name: tpl-{{ slsdotpath }}

--- a/salt/element/install.sls
+++ b/salt/element/install.sls
@@ -7,7 +7,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 {% if grains['nodename'] != 'dom0' -%}
 
 include:
-  - .install-repo
+  - {{ slsdotpath }}.install-repo
   - utils.tools.common.update
   - sys-audio.install-client
 

--- a/salt/fedora-minimal/create.sls
+++ b/salt/fedora-minimal/create.sls
@@ -10,7 +10,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
 include:
   - fedora.create
-  - .clone
+  - {{ slsdotpath }}.clone
 
 "dvm-{{ template.template }}-absent":
   qvm.absent:

--- a/salt/fedora-minimal/prefs.sls
+++ b/salt/fedora-minimal/prefs.sls
@@ -7,7 +7,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 {%- import slsdotpath ~ "/template.jinja" as template -%}
 
 include:
-  - .create
+  - {{ slsdotpath }}.create
 
 "{{ slsdotpath }}-set-management_dispvm-to-default":
   qvm.vm:

--- a/salt/fedora-xfce/create.sls
+++ b/salt/fedora-xfce/create.sls
@@ -9,7 +9,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 {%- import slsdotpath ~ "/template.jinja" as template -%}
 
 include:
-  - .clone
+  - {{ slsdotpath }}.clone
 
 "dvm-{{ template.template }}-absent":
   qvm.absent:

--- a/salt/fedora/create.sls
+++ b/salt/fedora/create.sls
@@ -9,7 +9,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 {%- import slsdotpath ~ "/template.jinja" as template -%}
 
 include:
-  - .clone
+  - {{ slsdotpath }}.clone
 
 "dvm-{{ template.template }}-absent":
   qvm.absent:

--- a/salt/fetcher/create.sls
+++ b/salt/fetcher/create.sls
@@ -7,7 +7,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 {%- from "qvm/template.jinja" import load -%}
 
 include:
-  - .clone
+  - {{ slsdotpath }}.clone
 
 {% load_yaml as defaults -%}
 name: tpl-{{ slsdotpath }}

--- a/salt/kicksecure-minimal/create.sls
+++ b/salt/kicksecure-minimal/create.sls
@@ -9,7 +9,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 {%- import slsdotpath ~ "/template.jinja" as template -%}
 
 include:
-  - .clone
+  - {{ slsdotpath }}.clone
 
 {% load_yaml as defaults -%}
 name: {{ template.template }}

--- a/salt/kicksecure-minimal/kernel-default.sls
+++ b/salt/kicksecure-minimal/kernel-default.sls
@@ -9,7 +9,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 {%- import slsdotpath ~ "/template.jinja" as template -%}
 
 include:
-  - .clone
+  - {{ slsdotpath }}.clone
 
 {% load_yaml as defaults -%}
 name: {{ template.template }}

--- a/salt/kicksecure-minimal/kernel-hvm.sls
+++ b/salt/kicksecure-minimal/kernel-hvm.sls
@@ -9,7 +9,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 {%- import slsdotpath ~ "/template.jinja" as template -%}
 
 include:
-  - .clone
+  - {{ slsdotpath }}.clone
 
 {% load_yaml as defaults -%}
 name: {{ template.template }}

--- a/salt/kicksecure-minimal/kernel-pv.sls
+++ b/salt/kicksecure-minimal/kernel-pv.sls
@@ -9,7 +9,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 {%- import slsdotpath ~ "/template.jinja" as template -%}
 
 include:
-  - .clone
+  - {{ slsdotpath }}.clone
   - utils.tools.common.update
 
 "{{ slsdotpath }}-installed":

--- a/salt/mail/create.sls
+++ b/salt/mail/create.sls
@@ -7,7 +7,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 {%- from "qvm/template.jinja" import load -%}
 
 include:
-  - .clone
+  - {{ slsdotpath }}.clone
 
 {% load_yaml as defaults -%}
 name: tpl-{{ slsdotpath }}-fetcher

--- a/salt/media/create.sls
+++ b/salt/media/create.sls
@@ -10,7 +10,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 {%- import "debian-minimal/template.jinja" as template -%}
 
 include:
-  - .clone
+  - {{ slsdotpath }}.clone
 
 {% load_yaml as defaults -%}
 name: tpl-{{ slsdotpath }}

--- a/salt/mgmt/create.sls
+++ b/salt/mgmt/create.sls
@@ -8,7 +8,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
 include:
   - fedora.create
-  - .clone
+  - {{ slsdotpath }}.clone
   - fedora-minimal.prefs
 
 {% load_yaml as defaults -%}

--- a/salt/mgmt/prefs.sls
+++ b/salt/mgmt/prefs.sls
@@ -5,7 +5,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 #}
 
 include:
-  - .create
+  - {{ slsdotpath }}.create
 
 "{{ slsdotpath }}-set-qubes-prefs-management_dispvm-to-dvm-{{ slsdotpath }}":
   cmd.run:

--- a/salt/mirage-builder/create.sls
+++ b/salt/mirage-builder/create.sls
@@ -7,7 +7,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 {%- from "qvm/template.jinja" import load -%}
 
 include:
-  - .clone
+  - {{ slsdotpath }}.clone
 
 {% load_yaml as defaults -%}
 name: tpl-{{ slsdotpath }}

--- a/salt/opentofu/create.sls
+++ b/salt/opentofu/create.sls
@@ -7,7 +7,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 {%- from "qvm/template.jinja" import load -%}
 
 include:
-  - .clone
+  - {{ slsdotpath }}.clone
 
 {% load_yaml as defaults -%}
 name: tpl-{{ slsdotpath }}

--- a/salt/opentofu/install.sls
+++ b/salt/opentofu/install.sls
@@ -7,7 +7,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 {% if grains['nodename'] != 'dom0' -%}
 
 include:
-  - .install-repo
+  - {{ slsdotpath }}.install-repo
   - utils.tools.common.update
   - sys-ssh-agent.install-client
 

--- a/salt/qubes-builder/configure-qusal.sls
+++ b/salt/qubes-builder/configure-qusal.sls
@@ -7,7 +7,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 {% if grains['nodename'] != 'dom0' -%}
 
 include:
-  - .configure
+  - {{ slsdotpath }}.configure
 
 "{{ slsdotpath }}-makedir-qusal-builder":
   file.directory:

--- a/salt/qubes-builder/create.sls
+++ b/salt/qubes-builder/create.sls
@@ -7,7 +7,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 {%- from "qvm/template.jinja" import load -%}
 
 include:
-  - .clone
+  - {{ slsdotpath }}.clone
   - fedora-minimal.prefs
 
 {% load_yaml as defaults -%}

--- a/salt/qubes-builder/init.sls
+++ b/salt/qubes-builder/init.sls
@@ -6,11 +6,11 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
 include:
 {% if grains['id'] == 'dom0' -%}
-  - .create
+  - {{ slsdotpath }}.create
 {% elif grains['id'] == 'tpl-' ~ slsdotpath -%}
-  - .install
+  - {{ slsdotpath }}.install
 {% elif grains['id'] == 'dvm-' ~ slsdotpath -%}
-  - .configure-qubes-executor
+  - {{ slsdotpath }}.configure-qubes-executor
 {% elif grains['id'] == slsdotpath -%}
-  - .configure
+  - {{ slsdotpath }}.configure
 {% endif -%}

--- a/salt/qubes-builder/install.sls
+++ b/salt/qubes-builder/install.sls
@@ -18,7 +18,7 @@ include:
   - sys-pgp.install-client
   - sys-ssh-agent.install-client
   - docker.install
-  - .install-qubes-executor
+  - {{ slsdotpath }}.install-qubes-executor
 
 "{{ slsdotpath }}-installed":
   pkg.installed:

--- a/salt/qubes-builder/prefs.sls
+++ b/salt/qubes-builder/prefs.sls
@@ -9,7 +9,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 ## https://github.com/QubesOS/qubes-issues/issues/8806
 
 include:
-  - .create
+  - {{ slsdotpath }}.create
 
 "{{ slsdotpath }}-set-management_dispvm-to-default":
   qvm.vm:

--- a/salt/reader/create.sls
+++ b/salt/reader/create.sls
@@ -8,7 +8,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 {%- from "qvm/template.jinja" import load -%}
 
 include:
-  - .clone
+  - {{ slsdotpath }}.clone
 
 {% load_yaml as defaults -%}
 name: tpl-{{ slsdotpath }}

--- a/salt/remmina/create.sls
+++ b/salt/remmina/create.sls
@@ -7,7 +7,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 {%- from "qvm/template.jinja" import load -%}
 
 include:
-  - .clone
+  - {{ slsdotpath }}.clone
 
 {% load_yaml as defaults -%}
 name: tpl-{{ slsdotpath }}

--- a/salt/signal/create.sls
+++ b/salt/signal/create.sls
@@ -7,7 +7,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 {%- from "qvm/template.jinja" import load -%}
 
 include:
-  - .clone
+  - {{ slsdotpath }}.clone
 
 {% load_yaml as defaults -%}
 name: tpl-{{ slsdotpath }}

--- a/salt/signal/install.sls
+++ b/salt/signal/install.sls
@@ -7,7 +7,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 {% if grains['nodename'] != 'dom0' -%}
 
 include:
-  - .install-repo
+  - {{ slsdotpath }}.install-repo
   - utils.tools.common.update
   - utils.tools.xfce
   - dotfiles.copy-x11

--- a/salt/ssh/create.sls
+++ b/salt/ssh/create.sls
@@ -7,7 +7,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 {%- from "qvm/template.jinja" import load -%}
 
 include:
-  - .clone
+  - {{ slsdotpath }}.clone
 
 {% load_yaml as defaults -%}
 name: tpl-{{ slsdotpath }}

--- a/salt/sys-audio/create.sls
+++ b/salt/sys-audio/create.sls
@@ -6,7 +6,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 {%- from "qvm/template.jinja" import load -%}
 
 include:
-  - .clone
+  - {{ slsdotpath }}.clone
 
 {% load_yaml as defaults -%}
 name: tpl-{{ slsdotpath }}

--- a/salt/sys-audio/install-bluetooth.sls
+++ b/salt/sys-audio/install-bluetooth.sls
@@ -8,7 +8,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
 include:
   - utils.tools.common.update
-  - .install
+  - {{ slsdotpath }}.install
   - sys-usb.install-client-proxy
 
 "{{ slsdotpath }}-bluetooth-installed":

--- a/salt/sys-audio/install.sls
+++ b/salt/sys-audio/install.sls
@@ -9,7 +9,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 include:
   - utils.tools.common.update
   - sys-usb.install-client-proxy
-  - .install-client
+  - {{ slsdotpath }}.install-client
 
 "{{ slsdotpath }}-installed":
   pkg.installed:

--- a/salt/sys-bitcoin/configure-builder-source.sls
+++ b/salt/sys-bitcoin/configure-builder-source.sls
@@ -11,7 +11,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 {% set bitcoin_tag = 'v' ~ version.version -%}
 
 include:
-  - .configure-builder-common
+  - {{ slsdotpath }}.configure-builder-common
 
 "{{ slsdotpath }}-source-makedir-src":
   file.directory:

--- a/salt/sys-bitcoin/configure-builder.sls
+++ b/salt/sys-bitcoin/configure-builder.sls
@@ -21,7 +21,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 {% set bitcoin_url_shasum_sig = bitcoin_url_dir ~ bitcoin_file_shasum_sig -%}
 
 include:
-  - .configure-builder-common
+  - {{ slsdotpath }}.configure-builder-common
 
 "{{ slsdotpath }}-remove-failed-download-or-verification":
   file.absent:

--- a/salt/sys-bitcoin/create.sls
+++ b/salt/sys-bitcoin/create.sls
@@ -9,7 +9,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 {%- import "whonix-gateway/template.jinja" as whonix_gateway %}
 
 include:
-  - .clone
+  - {{ slsdotpath }}.clone
 
 {% load_yaml as defaults -%}
 name: {{ slsdotpath }}-gateway

--- a/salt/sys-bitcoin/install-client.sls
+++ b/salt/sys-bitcoin/install-client.sls
@@ -7,7 +7,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 {% if grains['nodename'] != 'dom0' -%}
 
 include:
-  - .install-common
+  - {{ slsdotpath }}.install-common
   - dev.home-cleanup
   - dotfiles.copy-x11
   - dotfiles.copy-sh

--- a/salt/sys-bitcoin/install-source.sls
+++ b/salt/sys-bitcoin/install-source.sls
@@ -8,7 +8,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
 include:
   - utils.tools.common.update
-  - .install-common
+  - {{ slsdotpath }}.install-common
   - dotfiles.copy-ssh
   - dotfiles.copy-git
   - sys-git.install-client

--- a/salt/sys-bitcoin/install.sls
+++ b/salt/sys-bitcoin/install.sls
@@ -7,6 +7,6 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 {% if grains['nodename'] != 'dom0' -%}
 
 include:
-  - .install-common
+  - {{ slsdotpath }}.install-common
 
 {% endif -%}

--- a/salt/sys-cacher/create.sls
+++ b/salt/sys-cacher/create.sls
@@ -7,7 +7,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 {%- from "qvm/template.jinja" import load -%}
 
 include:
-  - .clone
+  - {{ slsdotpath }}.clone
   - browser.create
 
 {% load_yaml as defaults -%}

--- a/salt/sys-electrs/configure-builder.sls
+++ b/salt/sys-electrs/configure-builder.sls
@@ -7,6 +7,6 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 {% if grains['nodename'] != 'dom0' -%}
 
 include:
-  - .configure-builder-source
+  - {{ slsdotpath }}.configure-builder-source
 
 {% endif -%}

--- a/salt/sys-electrs/create.sls
+++ b/salt/sys-electrs/create.sls
@@ -7,7 +7,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 {%- from "qvm/template.jinja" import load -%}
 
 include:
-  - .clone
+  - {{ slsdotpath }}.clone
   - sys-bitcoin.create
 
 {% load_yaml as defaults -%}

--- a/salt/sys-electrs/install-builder.sls
+++ b/salt/sys-electrs/install-builder.sls
@@ -9,6 +9,6 @@ Source: https://github.com/romanz/electrs/blob/master/doc/install.md
 {% if grains['nodename'] != 'dom0' -%}
 
 include:
-  - .install-builder-source
+  - {{ slsdotpath }}.install-builder-source
 
 {% endif -%}

--- a/salt/sys-electrs/install.sls
+++ b/salt/sys-electrs/install.sls
@@ -9,6 +9,6 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 ## ElectRS does not provide official binaries. This state exists to be the
 ## default installation.
 include:
-  - .install-source
+  - {{ slsdotpath }}.install-source
 
 {% endif -%}

--- a/salt/sys-electrumx/create.sls
+++ b/salt/sys-electrumx/create.sls
@@ -7,7 +7,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 {%- from "qvm/template.jinja" import load -%}
 
 include:
-  - .clone
+  - {{ slsdotpath }}.clone
   - sys-bitcoin.create
 
 {% load_yaml as defaults -%}

--- a/salt/sys-firewall/create.sls
+++ b/salt/sys-firewall/create.sls
@@ -15,7 +15,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 {% endif -%}
 
 include:
-  - .clone
+  - {{ slsdotpath }}.clone
 
 {% load_yaml as defaults -%}
 name: tpl-{{ slsdotpath }}

--- a/salt/sys-git/create.sls
+++ b/salt/sys-git/create.sls
@@ -7,7 +7,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 {%- from "qvm/template.jinja" import load -%}
 
 include:
-  - .clone
+  - {{ slsdotpath }}.clone
 
 {% load_yaml as defaults -%}
 name: tpl-{{ slsdotpath }}

--- a/salt/sys-gui-gpu/create.sls
+++ b/salt/sys-gui-gpu/create.sls
@@ -11,7 +11,7 @@ SPDX-License-Identifier: GPL-2.0-only
 {%- from "qvm/template-gui.jinja" import gui_common -%}
 
 include:
-  - .clone
+  - {{ slsdotpath }}.clone
 
 "{{ slsdotpath }}-installed":
   pkg.installed:

--- a/salt/sys-gui-vnc/create.sls
+++ b/salt/sys-gui-vnc/create.sls
@@ -10,7 +10,7 @@ SPDX-License-Identifier: GPL-2.0-only
 {%- from "qvm/template-gui.jinja" import gui_common -%}
 
 include:
-  - .clone
+  - {{ slsdotpath }}.clone
 
 {% if 'psu' in salt['pillar.get']('qvm:sys-gui-vnc:dummy-modules', []) or 'backlight' in salt['pillar.get']('qvm:sys-gui-vnc:dummy-modules', []) %}
 "{{ slsdotpath }}-installed":

--- a/salt/sys-gui/cancel.sls
+++ b/salt/sys-gui/cancel.sls
@@ -5,7 +5,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 #}
 
 include:
-  - .cancel-common
+  - {{ slsdotpath }}.cancel-common
 
 "{{ slsdotpath }}-disable-autostart":
   qvm.prefs:

--- a/salt/sys-gui/create.sls
+++ b/salt/sys-gui/create.sls
@@ -10,7 +10,7 @@ SPDX-License-Identifier: GPL-2.0-only
 {%- from "qvm/template-gui.jinja" import gui_common -%}
 
 include:
-  - .clone
+  - {{ slsdotpath }}.clone
 
 {% if 'psu' in salt['pillar.get']('qvm:sys-gui:dummy-modules', []) or 'backlight' in salt['pillar.get']('qvm:sys-gui:dummy-modules', []) %}
 "{{ slsdotpath }}-installed":

--- a/salt/sys-net/create.sls
+++ b/salt/sys-net/create.sls
@@ -9,8 +9,8 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 {% set net_pcidevs = salt['grains.get']('pci_net_devs', []) -%}
 
 include:
-  - .clone
-  - .show-updatevm-origin
+  - {{ slsdotpath }}.clone
+  - {{ slsdotpath }}.show-updatevm-origin
 
 {% load_yaml as defaults -%}
 name: tpl-{{ slsdotpath }}

--- a/salt/sys-pgp/create.sls
+++ b/salt/sys-pgp/create.sls
@@ -7,7 +7,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 {%- from "qvm/template.jinja" import load -%}
 
 include:
-  - .clone
+  - {{ slsdotpath }}.clone
   - fedora-minimal.prefs
 
 {% load_yaml as defaults -%}

--- a/salt/sys-pgp/install-client.sls
+++ b/salt/sys-pgp/install-client.sls
@@ -7,6 +7,6 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 {% if grains['nodename'] != 'dom0' -%}
 
 include:
-  - .install
+  - {{ slsdotpath }}.install
 
 {% endif -%}

--- a/salt/sys-pgp/prefs.sls
+++ b/salt/sys-pgp/prefs.sls
@@ -5,7 +5,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 #}
 
 include:
-  - .create
+  - {{ slsdotpath }}.create
 
 "{{ slsdotpath }}-set-management_dispvm-to-default":
   qvm.vm:

--- a/salt/sys-print/create.sls
+++ b/salt/sys-print/create.sls
@@ -8,7 +8,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 {%- from "qvm/template.jinja" import load -%}
 
 include:
-  - .clone
+  - {{ slsdotpath }}.clone
 
 {% load_yaml as defaults -%}
 name: tpl-{{ slsdotpath }}

--- a/salt/sys-rsync/create.sls
+++ b/salt/sys-rsync/create.sls
@@ -8,7 +8,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 {%- from "qvm/template.jinja" import load -%}
 
 include:
-  - .clone
+  - {{ slsdotpath }}.clone
 
 {% load_yaml as defaults -%}
 name: tpl-{{ slsdotpath }}

--- a/salt/sys-ssh-agent/create.sls
+++ b/salt/sys-ssh-agent/create.sls
@@ -7,7 +7,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 {%- from "qvm/template.jinja" import load -%}
 
 include:
-  - .clone
+  - {{ slsdotpath }}.clone
 
 {% load_yaml as defaults -%}
 name: tpl-{{ slsdotpath }}

--- a/salt/sys-ssh/create.sls
+++ b/salt/sys-ssh/create.sls
@@ -8,7 +8,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 {%- from "qvm/template.jinja" import load -%}
 
 include:
-  - .clone
+  - {{ slsdotpath }}.clone
 
 {% load_yaml as defaults -%}
 name: tpl-{{ slsdotpath }}

--- a/salt/sys-syncthing/create.sls
+++ b/salt/sys-syncthing/create.sls
@@ -8,7 +8,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 {%- from "qvm/template.jinja" import load -%}
 
 include:
-  - .clone
+  - {{ slsdotpath }}.clone
   - browser.create
   - dom0.port-forward
 

--- a/salt/sys-syncthing/install-client.sls
+++ b/salt/sys-syncthing/install-client.sls
@@ -8,7 +8,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
 {% if grains['os_family']|lower == 'debian' -%}
 include:
-  - .install-repo
+  - {{ slsdotpath }}.install-repo
   - utils.tools.common.update
 {% endif -%}
 

--- a/salt/sys-syncthing/install.sls
+++ b/salt/sys-syncthing/install.sls
@@ -9,7 +9,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
 include:
 {% if grains['os_family']|lower == 'debian' -%}
-  - .install-repo
+  - {{ slsdotpath }}.install-repo
   - utils.tools.common.update
 {% endif -%}
   - utils.tools.xfce

--- a/salt/sys-tailscale/create.sls
+++ b/salt/sys-tailscale/create.sls
@@ -7,7 +7,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 {%- from "qvm/template.jinja" import load -%}
 
 include:
-  - .clone
+  - {{ slsdotpath }}.clone
 
 {% load_yaml as defaults -%}
 name: tpl-{{ slsdotpath }}

--- a/salt/sys-tailscale/install.sls
+++ b/salt/sys-tailscale/install.sls
@@ -7,7 +7,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 {% if grains['nodename'] != 'dom0' -%}
 
 include:
-  - .install-repo
+  - {{ slsdotpath }}.install-repo
   - utils.tools.common.update
 
 "{{ slsdotpath }}-systemd":

--- a/salt/sys-usb/create.sls
+++ b/salt/sys-usb/create.sls
@@ -8,7 +8,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 {%- from "qvm/template.jinja" import load -%}
 
 include:
-  - .clone
+  - {{ slsdotpath }}.clone
   - utils.tools.common.update
   - qvm.hide-usb-from-dom0
 

--- a/salt/sys-usb/install-client-cryptsetup.sls
+++ b/salt/sys-usb/install-client-cryptsetup.sls
@@ -8,7 +8,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
 include:
   - utils.tools.common.update
-  - .install-client-proxy
+  - {{ slsdotpath }}.install-client-proxy
 
 "{{ slsdotpath }}-installed-cryptsetup":
   pkg.installed:

--- a/salt/sys-usb/install-client-fido.sls
+++ b/salt/sys-usb/install-client-fido.sls
@@ -8,7 +8,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
 include:
   - utils.tools.common.update
-  - .install-client-proxy
+  - {{ slsdotpath }}.install-client-proxy
 
 "{{ slsdotpath }}-installed-fido":
   pkg.installed:

--- a/salt/sys-usb/install-client.sls
+++ b/salt/sys-usb/install-client.sls
@@ -7,7 +7,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 {% if grains['nodename'] != 'dom0' -%}
 
 include:
-  - .install-client-cryptsetup
-  - .install-client-fido
+  - {{ slsdotpath }}.install-client-cryptsetup
+  - {{ slsdotpath }}.install-client-fido
 
 {% endif -%}

--- a/salt/sys-wireguard/create.sls
+++ b/salt/sys-wireguard/create.sls
@@ -7,7 +7,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 {%- from "qvm/template.jinja" import load -%}
 
 include:
-  - .clone
+  - {{ slsdotpath }}.clone
 
 {% load_yaml as defaults -%}
 name: tpl-{{ slsdotpath }}

--- a/salt/terraform/create.sls
+++ b/salt/terraform/create.sls
@@ -7,7 +7,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 {%- from "qvm/template.jinja" import load -%}
 
 include:
-  - .clone
+  - {{ slsdotpath }}.clone
 
 {% load_yaml as defaults -%}
 name: tpl-{{ slsdotpath }}

--- a/salt/terraform/install.sls
+++ b/salt/terraform/install.sls
@@ -7,7 +7,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 {% if grains['nodename'] != 'dom0' -%}
 
 include:
-  - .install-repo
+  - {{ slsdotpath }}.install-repo
   - utils.tools.common.update
   - sys-ssh-agent.install-client
 

--- a/salt/usb/create.sls
+++ b/salt/usb/create.sls
@@ -7,7 +7,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 {%- from "qvm/template.jinja" import load -%}
 
 include:
-  - .clone
+  - {{ slsdotpath }}.clone
 
 {% load_yaml as defaults -%}
 name: tpl-{{ slsdotpath }}

--- a/salt/vault/create.sls
+++ b/salt/vault/create.sls
@@ -7,7 +7,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 {%- from "qvm/template.jinja" import load -%}
 
 include:
-  - .clone
+  - {{ slsdotpath }}.clone
 
 {% load_yaml as defaults -%}
 name: tpl-{{ slsdotpath }}

--- a/salt/video-companion/install-receiver-debug.sls
+++ b/salt/video-companion/install-receiver-debug.sls
@@ -8,7 +8,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
 include:
   - utils.tools.common.update
-  - .install-receiver
+  - {{ slsdotpath }}.install-receiver
 
 "{{ slsdotpath }}-receiver-debug-installed":
   pkg.installed:

--- a/salt/whonix-gateway/create.sls
+++ b/salt/whonix-gateway/create.sls
@@ -9,7 +9,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 {%- import slsdotpath ~ "/template.jinja" as template -%}
 
 include:
-  - .clone
+  - {{ slsdotpath }}.clone
 
 {% load_yaml as defaults -%}
 name: {{ template.template }}

--- a/salt/whonix-workstation/create.sls
+++ b/salt/whonix-workstation/create.sls
@@ -9,7 +9,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 {%- import slsdotpath ~ "/template.jinja" as template -%}
 
 include:
-  - .clone
+  - {{ slsdotpath }}.clone
   - whonix-gateway.create
 
 {% load_yaml as defaults -%}


### PR DESCRIPTION
Behavior of `.` includes have been changing between salt 3006.x and 3007. Explicitly prefixing with `slsdotpath` should make qusal work consistently across versions.

## Contribution checklist

Before contributing, I, the opener of this request:

-   [x] Agree to use the same license of each modified file;
-   [x] Have followed the [contribution guidelines](docs/CONTRIBUTE.md);
-   [x] Have tested it locally;
-   [x] Have committed locally and not through a git hosting service such as
    GitHub Web; and
-   [x] Have reviewed and updated any documentation if relevant.

Lacking to check any of the above can result in the rejection of the
contribution without no further comment.

## What does this PR aims to accomplish

This appears to be the only way I can consistently apply any qusal state. Without it, includes inside transitive states (like `debian-minimal` and `fedora-minimal`) break with salt not locating them.


## What does this PR change

Prefix local includes with `slsdotpath`.

Similarly in dotfiles: https://github.com/ben-grande/dotfiles/pull/4