### PR TITLE
sys-print: no netvm by default

### DIFF
--- a/salt/sys-print/README.md
+++ b/salt/sys-print/README.md
@@ -10,7 +10,10 @@ Printer environment in Qubes OS.
 *   [Access Control](#access-control)
 *   [Usage](#usage)
     *   [Add a printer](#add-a-printer)
+        *   [Network printers](#attaching-network-printers)
+        *   [USB printers](#attaching-usb-printers)
     *   [Print](#print)
+        *   [USB multi-function printers](#usb-multi-function-printers)
 *   [Credits](#credits)
 
 ## Description
@@ -109,20 +112,35 @@ qusal.Print * @tag:print-client @anyvm   deny
 
 ### Add a printer
 
-You will configure your printer from `sys-print` or `disp-sys-print`, it can
+You will configure your printer from `sys-print` or `disp-sys-print`. It can
 connect over the network or USB. If you do not want to save printing
 configuration, use `disp-sys-print`.
 
-On `sys-print` or `disp-sys-print`, add your printer:
+On `sys-print` or `disp-sys-print`, to add a printer after attaching it:
 
 ```sh
 system-config-printer
 ```
 
+#### Attaching network printers
+
+By default, `sys-print` and `disp-sys-print` have no NetVM.
+To access a network printer, attach a NetVM on its network to `sys-print`.
+
+#### Attaching USB printers
+
+Use `sys-usb` or `disp-sys-usb`. Identify the device by running `qvm-usb ls`
+in dom0 and attach it with `qvm-usb attach`.
+
 ### Print
 
 On the client, select the file to print, open it with an editor, viewer or
 browser and target the desired printer.
+
+### USB multi-function printers
+
+USB printers with both printing and scanning function can run into situations
+where [either scanning or printing does not work](https://fitzcarraldoblog.wordpress.com/2015/07/20/the-problem-of-scanning-using-usb-multi-function-printers-in-linux/).
 
 ## Credits
 

--- a/salt/sys-print/create.sls
+++ b/salt/sys-print/create.sls
@@ -35,7 +35,7 @@ present:
 prefs:
 - template: tpl-{{ slsdotpath }}
 - label: red
-- netvm: "*default*"
+- netvm: ""
 - audiovm: ""
 - vcpus: 1
 - memory: 300
@@ -70,7 +70,7 @@ present:
 prefs:
 - template: dvm-{{ slsdotpath }}
 - label: red
-- netvm: "*default*"
+- netvm: ""
 - audiovm: ""
 - vcpus: 1
 - memory: 300
@@ -105,7 +105,7 @@ present:
 prefs:
 - template: tpl-{{ slsdotpath }}
 - label: red
-- netvm: "*default*"
+- netvm: ""
 - audiovm: ""
 - vcpus: 1
 - memory: 300


### PR DESCRIPTION
## Contribution checklist

Before contributing, I, the opener of this request:

-   [x] Agree to use the same license of each modified file;
-   [x] Have followed the [contribution guidelines](docs/CONTRIBUTE.md);
-   [x] Have tested it locally;
-   [x] Have committed locally and not through a git hosting service such as
    GitHub Web; and
-   [x] Have reviewed and updated any documentation if relevant.

Lacking to check any of the above can result in the rejection of the
contribution without no further comment.

## What does this PR aims to accomplish

- Improve security and isolation
  - Printers shouldn't have internet or even network access by default, IMO
- Provide pointers for printer setup in usage docs

## What does this PR change

- Set `sys-print` and `disp-sys-print` to have no netvm by default
- Update readme
