### PR TITLE
Remove inexistent qubes-builder.prefs state from documentation

### DIFF
--- a/salt/qubes-builder/README.md
+++ b/salt/qubes-builder/README.md
@@ -40,7 +40,6 @@ sudo qubesctl --targets=tpl-mgmt state.apply
 sudo qubesctl state.apply qubes-builder.prefs-mgmt
 sudo qubesctl --targets=tpl-qubes-builder,dvm-qubes-builder,qubes-builder state.apply
 sudo qubesctl top.disable mgmt qubes-builder
-sudo qubesctl state.apply qubes-builder.prefs
 ```
 
 *   State:


### PR DESCRIPTION
Installing qubes-builder, I noticed a reference to an inexistent state.  I suppose we can safely remove this reference.